### PR TITLE
Fixes #9

### DIFF
--- a/sandbox/PerfBenchmark/Benchmark2.cs
+++ b/sandbox/PerfBenchmark/Benchmark2.cs
@@ -5,7 +5,6 @@ using Utf8Json;
 using Jil;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Attributes.Jobs;
 
 namespace PerfBenchmark
 {

--- a/sandbox/PerfBenchmark/PerfBenchmark.csproj
+++ b/sandbox/PerfBenchmark/PerfBenchmark.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.6.1.2" />
     <PackageReference Include="NetJSON" Version="1.2.1.10" />

--- a/sandbox/PerfBenchmark/Program.cs
+++ b/sandbox/PerfBenchmark/Program.cs
@@ -1,11 +1,9 @@
-﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Configs;
+﻿using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.CsProj;
 using PerfBenchmark;
 
 class Program
@@ -18,15 +16,11 @@ class Program
             typeof(DeserializeBenchmark),
             typeof(JsonSerializeBench)
         });
-
-        // args = new string[] { "0" };
-
+        
 #if DEBUG
         var b = new DeserializeBenchmark();
         b.Utf8JsonSerializer();
 #else
-
-
         switcher.Run(args);
 #endif
     }
@@ -36,11 +30,17 @@ public class BenchmarkConfig : ManualConfig
 {
     public BenchmarkConfig()
     {
-        Add(MarkdownExporter.GitHub);
-        Add(MemoryDiagnoser.Default);
+        IDiagnoser[] diagnosers = {
+            MemoryDiagnoser.Default
+        };
 
-        var baseConfig = Job.ShortRun.WithLaunchCount(1).WithTargetCount(1).WithWarmupCount(1);
-        Add(baseConfig.With(Runtime.Clr).With(Jit.RyuJit).With(Platform.X64));
-        //Add(baseConfig.With(Runtime.Core).With(Jit.RyuJit).With(CsProjCoreToolchain.NetCoreApp20));
+        IExporter[] exporters = {
+            MarkdownExporter.GitHub
+        };
+
+        AddDiagnoser(diagnosers);
+        AddExporter(exporters);
+
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core50).WithPlatform(Platform.X64));
     }
 }


### PR DESCRIPTION
Lets the benchmarks run again with latest benchmarkdotnet on .NET 5. Haven't updated the versions of the other projects we're testing against, but I want to write a bunch of different benchmarks to see performance per type before I go and do that work.