### PR TITLE
Fix behavior of escape-character in json string literal at JsonReader.ReadNextCore

### DIFF
--- a/src/Utf8Json/JsonReader.cs
+++ b/src/Utf8Json/JsonReader.cs
@@ -1008,8 +1008,8 @@ namespace Utf8Json
                     {
                         if (bytes[i] == (char)'\"')
                         {
-                            // is escape?
-                            if (bytes[i - 1] == (char)'\\')
+                            // is escape and that escape is not escaped?
+                            if (bytes[i - 1] == (char)'\\' && bytes[i - 2] != (char)'\\')
                             {
                                 continue;
                             }

--- a/tests/Utf8Json.Tests/DeserializeWithStringEscapeTest.cs
+++ b/tests/Utf8Json.Tests/DeserializeWithStringEscapeTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Text;
+using Xunit;
+
+namespace Utf8Json.Tests
+{
+    public class DeserializeWithStringEscapeTest
+    {
+        [Theory]
+        [InlineData(@"{""Name"":""\\"", ""Test"":""Something""}", "Something")]
+        [InlineData(@"{""Name"":"""", ""Test"":""Something""}", "Something")]
+        [InlineData(@"{""Name"":""\"""", ""Test"":""Something""}", "Something")]
+        [InlineData(@"{""Name"":""\""\"""", ""Test"":""Something""}", "Something")]
+        public void ShouldNotEscapeDoublequoteWithEscapedBackslash(string json, string expectedValue)
+        {
+            // Arrage
+            var reader = new JsonReader(Encoding.UTF8.GetBytes(json));
+
+            // Act
+            reader.ReadIsBeginObject();
+            var count = 0;
+            while (!reader.ReadIsEndObjectWithSkipValueSeparator(ref count))
+            {
+                var name = reader.ReadPropertyName();
+                if (name == "Test")
+                    reader.ReadString().Is(expectedValue);
+                else
+                {
+                    reader.ReadNextBlock();
+                }
+            }
+
+            reader.ReadIsValueSeparator();
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue [#96](https://github.com/neuecc/Utf8Json/pull/96)