### PR TITLE
Use global props file for all PackageReference package versions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100
+        dotnet-version: 5.0.301
     - name: Benchmark
       run: dotnet run --configuration Release -f net5.0 --filter '*' --runOncePerIteration

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 5.0.301
       - name: Create NuGet Package
         run: |
           vertag=(${GITHUB_REF//\// })

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100
+        dotnet-version: 5.0.301
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+
+  <!-- All projects will include the defined versions automatically -->
+  <Import Project="Versions.props" />
+
+</Project>

--- a/Versions.props
+++ b/Versions.props
@@ -1,0 +1,25 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftAspNetCoreMvcAbstractionsVersion>2.2.0</MicrosoftAspNetCoreMvcAbstractionsVersion>
+    <SystemCodeDomVersion>5.0.0</SystemCodeDomVersion>
+    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
+    <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
+    <SystemRuntimeSerializationPrimitives>4.7.0</SystemRuntimeSerializationPrimitives>
+    <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
+    <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
+
+    <!-- Build, Test, Code Analysis -->
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.10.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftNETTestSdkVersion>16.10.3</MicrosoftNETTestSdkVersion>
+    <XUnitVersion>2.4.1</XUnitVersion>
+
+    <!-- Benchmarking Package Versions -->
+    <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
+    <JilVersion>2.17.0</JilVersion>
+    <Version></Version>
+    <MessagePackVersion>2.2.85</MessagePackVersion>
+    <NetJSONVersion>1.3.7</NetJSONVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+    <ProtobufNetVersion>3.0.101</ProtobufNetVersion>
+  </PropertyGroup>
+</Project>

--- a/Versions.props
+++ b/Versions.props
@@ -4,16 +4,22 @@
     <SystemCodeDomVersion>5.0.0</SystemCodeDomVersion>
     <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
-    <SystemRuntimeSerializationPrimitives>4.7.0</SystemRuntimeSerializationPrimitives>
+    <SystemRuntimeSerializationPrimitives>4.3.0</SystemRuntimeSerializationPrimitives>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
 
-    <!-- Build, Test, Code Analysis -->
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.10.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
-    <MicrosoftNETTestSdkVersion>16.10.3</MicrosoftNETTestSdkVersion>
-    <XUnitVersion>2.4.1</XUnitVersion>
+    <!--
+      Build, Test, Code Analysis
+    -->
+    <!-- Note: v3.10.0+ causes: src\Utf8Json.UniversalCodeGenerator\CodeAnalysis\TypeCollector.cs(206,32,206,58): warning RS1024: Compare symbols correctly -->
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.9.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftNETTestSdkVersion>16.10.0</MicrosoftNETTestSdkVersion>
+    <!-- Note: Cannot use 2.4.0+, unless https://github.com/xunit/xunit/issues/1771 is fixed -->
+    <XUnitVersion>2.2.0</XUnitVersion>
 
-    <!-- Benchmarking Package Versions -->
+    <!--
+      Benchmark
+    -->
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <JilVersion>2.17.0</JilVersion>
     <Version></Version>

--- a/sandbox/ConsoleAppNetCore/Program.cs
+++ b/sandbox/ConsoleAppNetCore/Program.cs
@@ -323,11 +323,8 @@ namespace ConsoleAppNetCore
 
         public class E
         {
-            int x;
-
             public E()
             {
-                x = 9;
             }
         }
 

--- a/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
+++ b/sandbox/DynamicCodeDumper/DynamicCodeDumper.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CodeDom" Version="5.0.0" />
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/sandbox/PerfBenchmark/PerfBenchmark.csproj
+++ b/sandbox/PerfBenchmark/PerfBenchmark.csproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="Jil" Version="2.17.0" />
-    <PackageReference Include="MessagePack" Version="2.2.85" />
-    <PackageReference Include="NetJSON" Version="1.3.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="protobuf-net" Version="3.0.101" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="Jil" Version="$(JilVersion)" />
+    <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
+    <PackageReference Include="NetJSON" Version="$(NetJSONVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="protobuf-net" Version="$(ProtobufNetVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Utf8Json.AspNetCoreMvcFormatter/Utf8Json.AspNetCoreMvcFormatter.csproj
+++ b/src/Utf8Json.AspNetCoreMvcFormatter/Utf8Json.AspNetCoreMvcFormatter.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="$(MicrosoftAspNetCoreMvcAbstractionsVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Utf8Json.CodeGenerator/Utf8Json.CodeGenerator.csproj
+++ b/src/Utf8Json.CodeGenerator/Utf8Json.CodeGenerator.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CodeDom" Version="5.0.0" />
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Utf8Json.ImmutableCollection/Utf8Json.ImmutableCollection.csproj
+++ b/src/Utf8Json.ImmutableCollection/Utf8Json.ImmutableCollection.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+        <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Utf8Json.UnityShims/Utf8Json.UnityShims.csproj
+++ b/src/Utf8Json.UnityShims/Utf8Json.UnityShims.csproj
@@ -24,7 +24,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemRuntimeSerializationPrimitives)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Utf8Json.UniversalCodeGenerator/Mono.Options/Options.cs
+++ b/src/Utf8Json.UniversalCodeGenerator/Mono.Options/Options.cs
@@ -720,7 +720,6 @@ namespace Mono.Options
             get { return this.option; }
         }
 
-        [SecurityPermission(SecurityAction.LinkDemand, SerializationFormatter = true)]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/Utf8Json.UniversalCodeGenerator/Utf8Json.UniversalCodeGenerator.csproj
+++ b/src/Utf8Json.UniversalCodeGenerator/Utf8Json.UniversalCodeGenerator.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
-        <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
+        <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemRuntimeSerializationPrimitives)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Utf8Json/Utf8Json.csproj
+++ b/src/Utf8Json/Utf8Json.csproj
@@ -32,10 +32,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
-        <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+        <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
+        <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitVersion)" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
+        <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Utf8Json.Tests/DataContractTest.cs
+++ b/tests/Utf8Json.Tests/DataContractTest.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/tests/Utf8Json.Tests/Utf8Json.Tests.csproj
+++ b/tests/Utf8Json.Tests/Utf8Json.Tests.csproj
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. Use Version.props to define required package versions (add comments if a package cannot be the latest)
2. In all csproj file use the defined version property value  when using PackageReference. This will simplify to upgrade the packages to the latest
3. Fix all compiler warnings
4. Use latest .NET 5.0 SDK in gitflow (5.0.301)