### PR TITLE
feat: Ignore case enum parsing

### DIFF
--- a/src/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/Utf8Json/Formatters/EnumFormatter.cs
@@ -250,7 +250,7 @@ namespace Utf8Json.Formatters
                 if (!nameValueMapping.TryGetValue(key, out value))
                 {
                     var str = StringEncoding.UTF8.GetString(key.Array, key.Offset, key.Count);
-                    value = (T)Enum.Parse(typeof(T), str); // Enum.Parse is slow
+                    value = (T)Enum.Parse(typeof(T), str, true); // Enum.Parse is slow
                 }
                 return value;
             }


### PR DESCRIPTION
Issue scenario:
We are serializing our own object (CompanyModel) which contains enum (Pending) with camel-case resolver. The serilalized json string contains now the enum string camel-cased (pending). Now I try to deserialize this json string back to CompanyModel object but I get an error that says that 'pending' enum is missing, but it is not missing it just written as 'Pending' in the Model. 

We need to ignore case  for enum parsing.
Can you approve this PR?